### PR TITLE
add locale selection with German support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ The icons are not included in that license. See "Thanks" below for details on th
 - XPT2046_Touchscreen 1.4
 - lvgl 9.2.2
 
+### Adding a new language
+
+1. Copy an existing locale file from `aura/` (for example `en.h`) and rename
+   it using your two-letter language code (`fr.h` for French, etc.).
+2. Translate all strings in the new file and update the weekday array.
+3. Declare your locale in `aura/locales.cpp` and extend
+   `get_locale_by_code()` in `aura/locales.cpp` so it returns your new
+   structure when the matching code is provided.
+4. Add the language name to the `locale_opts` string and update the selection
+   logic in `settings_event_handler` within `aura/weather.ino` to map the
+   dropdown index to the new locale code.
+5. Rebuild and flash the firmware.
+
 ### Thanks & Credits
 
 - Weather icons from https://github.com/mrdarrengriffin/google-weather-icons/tree/main/v2

--- a/aura/de.h
+++ b/aura/de.h
@@ -1,0 +1,29 @@
+#include "locales.h"
+
+static const char* const WEEKDAYS_DE[7] = {"So","Mo","Di","Mi","Do","Fr","Sa"};
+
+const LocaleStrings LOCALE_DE = {
+    "de",
+    "Deutsch",
+    "Aura Einstellungen",
+    "Helligkeit:",
+    "Ort:",
+    "Ort",
+    "Nutze °F:",
+    "24 Std:",
+    "WLAN reset",
+    "Schliessen",
+    "Ort festlegen",
+    "Stadt:",
+    "Suchergebnisse",
+    "Speichern",
+    "Abbrechen",
+    "7-TAGE VORHERSAGE",
+    "STUNDEN-VORHERSAGE",
+    "Gefuehlt",
+    "Jetzt",
+    "Heute",
+    "Sprache:",
+    { WEEKDAYS_DE[0], WEEKDAYS_DE[1], WEEKDAYS_DE[2], WEEKDAYS_DE[3], WEEKDAYS_DE[4], WEEKDAYS_DE[5], WEEKDAYS_DE[6] }
+};
+

--- a/aura/en.h
+++ b/aura/en.h
@@ -1,0 +1,29 @@
+#include "locales.h"
+
+static const char* const WEEKDAYS_EN[7] = {"Sun","Mon","Tues","Wed","Thurs","Fri","Sat"};
+
+const LocaleStrings LOCALE_EN = {
+    "en",
+    "English",
+    "Aura Settings",
+    "Brightness:",
+    "Location:",
+    "Location",
+    "Use °F:",
+    "24hr:",
+    "Reset Wi-Fi",
+    "Close",
+    "Change Location",
+    "City:",
+    "Search Results",
+    "Save",
+    "Cancel",
+    "SEVEN DAY FORECAST",
+    "HOURLY FORECAST",
+    "Feels Like",
+    "Now",
+    "Today",
+    "Language:",
+    { WEEKDAYS_EN[0], WEEKDAYS_EN[1], WEEKDAYS_EN[2], WEEKDAYS_EN[3], WEEKDAYS_EN[4], WEEKDAYS_EN[5], WEEKDAYS_EN[6] }
+};
+

--- a/aura/locales.cpp
+++ b/aura/locales.cpp
@@ -1,0 +1,8 @@
+#include "en.h"
+#include "de.h"
+
+const LocaleStrings* get_locale_by_code(const char* code) {
+    if(strcmp(code, "de") == 0) return &LOCALE_DE;
+    return &LOCALE_EN;
+}
+

--- a/aura/locales.h
+++ b/aura/locales.h
@@ -1,0 +1,36 @@
+#ifndef LOCALES_H
+#define LOCALES_H
+
+#include <Arduino.h>
+
+typedef struct {
+    const char *code; // e.g. "en"
+    const char *name; // for dropdown
+    const char *settings_title;
+    const char *brightness;
+    const char *location_label;
+    const char *location_button;
+    const char *use_f;
+    const char *clock_24hr;
+    const char *reset_wifi;
+    const char *close;
+    const char *change_location_title;
+    const char *city;
+    const char *search_results;
+    const char *save;
+    const char *cancel;
+    const char *seven_day_forecast;
+    const char *hourly_forecast;
+    const char *feels_like;
+    const char *now;
+    const char *today;
+    const char *language_label;
+    const char *weekdays[7];
+} LocaleStrings;
+
+extern const LocaleStrings LOCALE_EN;
+extern const LocaleStrings LOCALE_DE;
+
+const LocaleStrings* get_locale_by_code(const char* code);
+
+#endif // LOCALES_H


### PR DESCRIPTION
- Added structured locale data, including German translations, so text like “Aura Settings” and “Brightness:” are now available
- Included English defaults in a similar locale definition to maintain compatibility
- Introduced a function to switch locales dynamically, storing the user’s choice and updating the weekday labels accordingly
- Added a dropdown in the settings window for language selection, which reloads the UI in the chosen language
- Loaded the saved locale from preferences during setup so the interface starts in the user’s selected language

![IMG_4653_m](https://github.com/user-attachments/assets/5fa8a5c8-cd8f-461f-bb3f-64812bbd59cf)
